### PR TITLE
🤖 [openai/codex] Add Discord bot integration option

### DIFF
--- a/main.py
+++ b/main.py
@@ -15,6 +15,7 @@ from dotenv import load_dotenv
 
 from src.agents import GitHubIntegrationAgent
 from src.cli_interface import show_help_summary
+from src.discord_integration import start_discord_bot
 
 # Import all modules
 from src.workflow import run
@@ -82,6 +83,11 @@ def main():
         action="store_true",
         help="Create a pull request (requires --commit)",
     )
+    parser.add_argument(
+        "--discord-bot",
+        action="store_true",
+        help="Run Discord bot to receive prompts",
+    )
     args = parser.parse_args()
 
     if args.create_pr:
@@ -99,6 +105,10 @@ def main():
             "💡 Use: --commit --create-pr to commit changes and create a pull request"
         )
         sys.exit(1)
+
+    if args.discord_bot:
+        start_discord_bot(args.repo_url, args.workdir)
+        return
 
     if args.show_commands:
         show_help_summary()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ composio>=0.3.0
 python-dotenv>=1.0.0
 pydantic>=2.0.0
 openai>=1.0.0
+discord.py>=2.3.2

--- a/src/discord_integration.py
+++ b/src/discord_integration.py
@@ -1,0 +1,42 @@
+import os
+
+import discord
+
+from .workflow import run
+
+
+class OrionClient(discord.Client):
+    def __init__(self, repo_url: str | None = None, workdir: str | None = None, **kwargs) -> None:
+        intents = kwargs.get("intents", discord.Intents.default())
+        super().__init__(intents=intents)
+        self.repo_url = repo_url or os.environ.get(
+            "REPO_URL", "https://github.com/ishandutta0098/open-clip"
+        )
+        self.workdir = workdir or os.environ.get("WORKDIR", os.getcwd())
+
+    async def on_ready(self) -> None:
+        print(f"🤖 Logged in as {self.user}")
+
+    async def on_message(self, message: discord.Message) -> None:
+        if message.author == self.user:
+            return
+        text = message.content.strip()
+        if not text:
+            return
+        await message.channel.send(f"🤖 Running AI agent with prompt: {text}")
+        run(self.repo_url, text, self.workdir)
+        await message.channel.send("✅ Task completed")
+
+
+def start_discord_bot(repo_url: str | None = None, workdir: str | None = None) -> None:
+    """Start a Discord bot to receive prompts and run the workflow."""
+    token = os.environ.get("DISCORD_BOT_TOKEN")
+    if not token:
+        print("❌ Missing Discord token. Set DISCORD_BOT_TOKEN.")
+        return
+
+    intents = discord.Intents.default()
+    intents.message_content = True
+    client = OrionClient(repo_url=repo_url, workdir=workdir, intents=intents)
+    print("🤖 Discord bot running...")
+    client.run(token)


### PR DESCRIPTION
## Summary
- add a discord bot integration
- wire new `--discord-bot` option into `main.py`

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688a4014f7788329b2a5251bedf63878