### PR TITLE
:robot: [openai/codex] Send repository explanation to Discord

### DIFF
--- a/src/code_explainer.py
+++ b/src/code_explainer.py
@@ -38,8 +38,15 @@ def _summarize_repository(repo_path: str) -> str:
     return "\n".join(sorted(lines))
 
 
-def explain_repository(repo_url: str, workdir: str, branch: Optional[str] = None) -> None:
-    """Clone a repository and generate an OpenAI-powered explanation."""
+def explain_repository(
+    repo_url: str, workdir: str, branch: Optional[str] = None
+) -> str:
+    """Clone a repository and generate an OpenAI-powered explanation.
+
+    Returns the explanation string so it can be consumed by callers
+    (e.g., the Discord bot) in addition to being printed to the
+    terminal.
+    """
     repo_name = os.path.splitext(os.path.basename(repo_url.rstrip('/')))[0]
     repo_path = os.path.join(workdir, repo_name)
 
@@ -71,6 +78,10 @@ def explain_repository(repo_url: str, workdir: str, branch: Optional[str] = None
             f"Failed to generate explanation via OpenAI API: {e}\n" f"\n{summary}"
         )
 
-    print(f"\n📚 Codebase overview for {repo_name} (branch: {branch or 'default'})")
+    print(
+        f"\n📚 Codebase overview for {repo_name} (branch: {branch or 'default'})"
+    )
     print("=" * 60)
     print(explanation)
+
+    return explanation


### PR DESCRIPTION
## Summary
- return explanation text from `explain_repository`
- deliver explanation directly in Discord messages, chunking long outputs

## Testing
- `python -m pytest`
- `python -m py_compile src/code_explainer.py src/discord_integration.py`


------
https://chatgpt.com/codex/tasks/task_e_6894c30167e083299792f68fa7a98ef1